### PR TITLE
ユーザ選択で履歴を絞り込む機能の追加

### DIFF
--- a/src/features/roomHistory/RoomHistory.tsx
+++ b/src/features/roomHistory/RoomHistory.tsx
@@ -26,7 +26,8 @@ const RoomHistory = () => {
     error,
     isLoading,
   } = useGetAPI<LogsListResponce>(
-    `${endpoints.logs}?offset=${CurrentOffset}${selectedUserID ? `&&user-id=${selectedUserID}` : ''
+    `${endpoints.logs}?offset=${CurrentOffset}${
+      selectedUserID ? `&&user-id=${selectedUserID}` : ''
     }`,
   );
   const [isGantt, setIsGantt] = useState(false);

--- a/src/features/roomHistory/RoomHistory.tsx
+++ b/src/features/roomHistory/RoomHistory.tsx
@@ -26,14 +26,13 @@ const RoomHistory = () => {
     error,
     isLoading,
   } = useGetAPI<LogsListResponce>(
-    `${endpoints.logs}?offset=${CurrentOffset}${
-      selectedUserID ? `&&user-id=${selectedUserID}` : ''
+    `${endpoints.logs}?offset=${CurrentOffset}${selectedUserID ? `&&user-id=${selectedUserID}` : ''
     }`,
   );
   const [isGantt, setIsGantt] = useState(false);
 
   const Period = (roomHistoryLog?: LogsListResponce) => {
-    if (!roomHistoryLog || !roomHistoryLog.logs) return <p>history data is null</p>;
+    if (!roomHistoryLog || !roomHistoryLog.logs) return null;
     const log = roomHistoryLog.logs;
     if (isLoading) return <Loading message='滞在情報取得中' />;
     if (error) return <Error message='滞在情報取得失敗' />;

--- a/src/features/roomHistory/RoomHistory.tsx
+++ b/src/features/roomHistory/RoomHistory.tsx
@@ -9,7 +9,7 @@ import { useCurrentPage } from './roomHistoryhook';
 import { Button } from '@/components/common/Button';
 import Error from '@/components/common/Error';
 import Loading from '@/components/common/Loading';
-import * as RoomHistoryComponents from "@/features/roomHistory/components/Index"
+import * as RoomHistoryComponents from '@/features/roomHistory/components/Index';
 import { useGetAPI } from '@/hooks/useGetAPI';
 import Log from '@/types/log';
 import { UserAttribute } from '@/types/user';
@@ -26,8 +26,15 @@ const RoomHistory = () => {
 
   const selectedUserID = searchParams.get('user-id') || undefined;
 
-  const { data: logs, error, isLoading } = useGetAPI<Log[]>(
-    `${endpoints.logs}?offset=${CurrentOffset}${selectedUserID ? `&&user-id=${selectedUserID}` : ''}`);
+  const {
+    data: logs,
+    error,
+    isLoading,
+  } = useGetAPI<Log[]>(
+    `${endpoints.logs}?offset=${CurrentOffset}${
+      selectedUserID ? `&&user-id=${selectedUserID}` : ''
+    }`,
+  );
   const [isGantt, setIsGantt] = useState(false);
 
   const updateQueryParams = (params: Record<string, string | undefined>) => {
@@ -71,17 +78,17 @@ const RoomHistory = () => {
     if (users)
       return (
         <Select
-          placeholder="user name"
+          placeholder='user name'
           data={
             users
-              ? users.map(user => ({
-                value: user.id.toString(),
-                label: user.name
-              }))
+              ? users.map((user) => ({
+                  value: user.id.toString(),
+                  label: user.name,
+                }))
               : []
           }
           searchable
-          nothingFoundMessage="ユーザが見つかりません"
+          nothingFoundMessage='ユーザが見つかりません'
           onChange={handleUserChange}
           value={selectedUserID}
         />
@@ -165,7 +172,9 @@ const RoomHistory = () => {
         if (width > 853) {
           return (
             <div>
-              <div className='fixed inset-y-1/2 left-4'>{RoomHistoryComponents.prevButton(CurrentPage, PreviousPage)}</div>
+              <div className='fixed inset-y-1/2 left-4'>
+                {RoomHistoryComponents.prevButton(CurrentPage, PreviousPage)}
+              </div>
               <div className='fixed inset-y-1/2 right-4'>{nextButton()}</div>
             </div>
           );

--- a/src/features/roomHistory/components/Index.ts
+++ b/src/features/roomHistory/components/Index.ts
@@ -1,0 +1,3 @@
+import prevButton from "./PrevButton";
+
+export { prevButton };

--- a/src/features/roomHistory/components/Index.ts
+++ b/src/features/roomHistory/components/Index.ts
@@ -1,3 +1,5 @@
-import prevButton from './PrevButton';
+import NextButton from './NextButton';
+import PrevButton from './PrevButton';
+import UserSelecter from './UserSelecter';
 
-export { prevButton };
+export { NextButton, PrevButton, UserSelecter };

--- a/src/features/roomHistory/components/Index.ts
+++ b/src/features/roomHistory/components/Index.ts
@@ -1,3 +1,3 @@
-import prevButton from "./PrevButton";
+import prevButton from './PrevButton';
 
 export { prevButton };

--- a/src/features/roomHistory/components/NextButton.tsx
+++ b/src/features/roomHistory/components/NextButton.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@mantine/core';
+
+const nextButton = (CurrentPage: number, NextPage: () => void, HistoryCount: number) => {
+  const limit = 30;
+  const MaxPage = HistoryCount / limit;
+  if (CurrentPage >= MaxPage) {
+    return <div />;
+  }
+  return (
+    <Button color='blue' onClick={NextPage}>
+      次へ
+    </Button>
+  );
+};
+
+export default nextButton;

--- a/src/features/roomHistory/components/PrevButton.tsx
+++ b/src/features/roomHistory/components/PrevButton.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@mantine/core";
+
+const prevButton = (CurrentPage: number, PreviousPage: () => void) => {
+    //pageが1より大きい時にボタンを表示
+    if (CurrentPage > 1) {
+        return (
+            <Button color='blue' onClick={PreviousPage}>
+                前へ
+            </Button>
+        );
+    }
+    return <div />;
+};
+
+export default prevButton;

--- a/src/features/roomHistory/components/PrevButton.tsx
+++ b/src/features/roomHistory/components/PrevButton.tsx
@@ -1,15 +1,15 @@
-import { Button } from "@mantine/core";
+import { Button } from '@mantine/core';
 
 const prevButton = (CurrentPage: number, PreviousPage: () => void) => {
-    //pageが1より大きい時にボタンを表示
-    if (CurrentPage > 1) {
-        return (
-            <Button color='blue' onClick={PreviousPage}>
-                前へ
-            </Button>
-        );
-    }
-    return <div />;
+  //pageが1より大きい時にボタンを表示
+  if (CurrentPage > 1) {
+    return (
+      <Button color='blue' onClick={PreviousPage}>
+        前へ
+      </Button>
+    );
+  }
+  return <div />;
 };
 
 export default prevButton;

--- a/src/features/roomHistory/components/PrevButton.tsx
+++ b/src/features/roomHistory/components/PrevButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mantine/core';
 
-const prevButton = (CurrentPage: number, PreviousPage: () => void) => {
+const PrevButton = (CurrentPage: number, PreviousPage: () => void) => {
   //pageが1より大きい時にボタンを表示
   if (CurrentPage > 1) {
     return (
@@ -12,4 +12,4 @@ const prevButton = (CurrentPage: number, PreviousPage: () => void) => {
   return <div />;
 };
 
-export default prevButton;
+export default PrevButton;

--- a/src/features/roomHistory/components/UserSelecter.tsx
+++ b/src/features/roomHistory/components/UserSelecter.tsx
@@ -1,0 +1,43 @@
+import { Select } from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import { useHandleUserChange } from '../roomHistoryhook';
+import Error from '@/components/common/Error';
+import Loading from '@/components/common/Loading';
+import { useGetAPI } from '@/hooks/useGetAPI';
+import { UserAttribute } from '@/types/user';
+import { endpoints } from '@/utils/endpoint';
+
+// eslint-disable-next-line no-unused-vars
+const UserSelecter = (selectedUserID?: string) => {
+  const handleUserChange = useHandleUserChange();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { data: users, error, isLoading } = useGetAPI<UserAttribute[]>(`${endpoints.users}`);
+  const [selectedUser, setSelectedUser] = useState<string | null>(selectedUserID || null);
+
+  useEffect(() => {
+    setSelectedUser(selectedUserID || null);
+  }, [selectedUserID]);
+
+  if (isLoading) return <Loading message='利用者情報取得中' />;
+  if (error) return <Error message='利用者情報取得失敗' />;
+  if (users)
+    return (
+      <Select
+        placeholder='user name'
+        data={
+          users
+            ? users.map((user) => ({
+                value: user.id.toString(),
+                label: user.name,
+              }))
+            : []
+        }
+        searchable
+        nothingFoundMessage='ユーザが見つかりません'
+        onChange={handleUserChange}
+        value={selectedUser}
+      />
+    );
+};
+
+export default UserSelecter;

--- a/src/features/roomHistory/roomHistoryhook.ts
+++ b/src/features/roomHistory/roomHistoryhook.ts
@@ -1,15 +1,54 @@
-import { useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
-export const useCurrentPage = (): [number, () => void, () => void] => {
-  const [currentPage, setCurrentPage] = useState(1);
+export const useCurrentPage = (): [number, number, () => void, () => void] => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pageParam = searchParams.get('page');
+  const currentPage = pageParam ? parseInt(pageParam, 10) : 1;
+
+  const limit = 30;
+
+  const updatePage = (newPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('page', newPage.toString());
+    router.push(`?${params.toString()}`, { scroll: false }); // ページ遷移を防ぐ
+  };
 
   const NextPage = () => {
-    setCurrentPage(currentPage + 1);
+    updatePage(currentPage + 1);
   };
 
   const PreviousPage = () => {
-    setCurrentPage(currentPage - 1);
+    updatePage(currentPage - 1);
   };
 
-  return [currentPage, PreviousPage, NextPage];
+  const currentOffset = (currentPage - 1) * limit;
+
+  return [currentOffset, currentPage, PreviousPage, NextPage];
+};
+
+export const useHandleUserChange = () => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const pathname = usePathname();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const updateQueryParams = (params: Record<string, string | undefined>) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+
+    Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined) {
+        newParams.delete(key);
+      } else {
+        newParams.set(key, value);
+      }
+    });
+
+    router.push(`${pathname}?${newParams.toString()}`, { scroll: false });
+  };
+
+  return (value: string | null) => {
+    updateQueryParams({ 'user-id': value || undefined });
+  };
 };

--- a/src/globalStates/useCommunityState.ts
+++ b/src/globalStates/useCommunityState.ts
@@ -1,7 +1,7 @@
 import { atom, useRecoilValue, useSetRecoilState } from 'recoil';
 
 const community = atom({
-  key: 'communty',
+  key: 'community',
   default: {
     communityId: -1,
     communityName: '',

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -6,4 +6,10 @@ type Log = {
   room: string;
 };
 
-export default Log;
+type LogsListResponce = {
+  logs?: Log[];
+  count: number;
+}
+
+// export default Log;
+export default LogsListResponce;

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -9,7 +9,7 @@ type Log = {
 type LogsListResponce = {
   logs?: Log[];
   count: number;
-}
+};
 
 // export default Log;
 export default LogsListResponce;


### PR DESCRIPTION
・ユーザ名を選択するとhandleUserChangeが呼び出されuser-idで絞り込む
・handleUserChangeでユーザが選択されない場合「user-id=~」が未入力になる形に
・入力での選択も可能（当てはまるユーザがいない場合「ユーザが見つかりません」の表示が出る）
・入力前は「user name」が表示される
・offset、limitには未対応
・履歴とグラフの切り替えボタンの横に欄を作っただけなため画面上のレイアウトも後々変更する