### PR TITLE
実験中のビーコンを現在の滞在者に表示しないように

### DIFF
--- a/src/features/stayer/Stayer.tsx
+++ b/src/features/stayer/Stayer.tsx
@@ -38,7 +38,7 @@ const Stayer = () => {
                 <td className='px-2 text-sm md:text-2xl'>{stayersInRoom.room}</td>
                 <td className='border'>
                   {stayersInRoom.stayers.map((stayerInRoom) => {
-                    if (stayerInRoom.name.includes("実験")) return null;
+                    if (stayerInRoom.name.includes('実験')) return null;
                     return (
                       <div className='p-0.5 text-sm md:py-2 md:text-2xl' key={stayerInRoom.name}>
                         {stayerInRoom.name}（

--- a/src/features/stayer/Stayer.tsx
+++ b/src/features/stayer/Stayer.tsx
@@ -37,18 +37,21 @@ const Stayer = () => {
               <tr className='border text-left' key={stayersInRoom.room}>
                 <td className='px-2 text-sm md:text-2xl'>{stayersInRoom.room}</td>
                 <td className='border'>
-                  {stayersInRoom.stayers.map((stayerInRoom) => (
-                    <div className='p-0.5 text-sm md:py-2 md:text-2xl' key={stayerInRoom.name}>
-                      {stayerInRoom.name}（
-                      {stayerInRoom.tags.map((tag, index) => (
-                        <span key={tag.id}>
-                          {tag.name}
-                          {index !== stayerInRoom.tags.length - 1 && ' , '}
-                        </span>
-                      ))}
-                      ）
-                    </div>
-                  ))}
+                  {stayersInRoom.stayers.map((stayerInRoom) => {
+                    if (stayerInRoom.name.includes("実験")) return null;
+                    return (
+                      <div className='p-0.5 text-sm md:py-2 md:text-2xl' key={stayerInRoom.name}>
+                        {stayerInRoom.name}（
+                        {stayerInRoom.tags.map((tag, index) => (
+                          <span key={tag.id}>
+                            {tag.name}
+                            {index !== stayerInRoom.tags.length - 1 && ' , '}
+                          </span>
+                        ))}
+                        ）
+                      </div>
+                    );
+                  })}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## 変更の理由
現在の滞在者にhayashi(実験)などが混在していると非常に見づらい

## アプローチ
応急処置的な修正にはなるがユーザ名に"実験"を含むビーコンを現在の滞在者に表示しないようにした．
滞在ログには表示される．

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 名前に「実験」を含む滞在者が一覧に表示されないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->