### PR TITLE
Hotfix: ユーザログページでAPIレスポンス404エラーで表示されない問題の解決

### DIFF
--- a/src/features/roomHistory/components/RoomHistory.tsx
+++ b/src/features/roomHistory/components/RoomHistory.tsx
@@ -10,6 +10,7 @@ import UserSelecter from './UserSelecter';
 import Error from '@/components/common/Error';
 import Loading from '@/components/common/Loading';
 import { StayLogGraph } from '@/features/stayLogGraph/components/StayLogGraph';
+import { useCommunityState } from '@/globalStates/useCommunityState';
 import { useGetAPI } from '@/hooks/useGetAPI';
 import { LogsListResponse } from '@/types/log';
 import { UserAttribute } from '@/types/user';
@@ -21,6 +22,7 @@ const RoomHistory = () => {
   const [currentOffset, currentPage, currentUserID, previousPage, nextPage, updateSelectedUser] =
     useParamChange();
   const [isGantt, setIsGantt] = useState(false);
+  const community = useCommunityState();
 
   const {
     data: roomHistoryLog,
@@ -34,7 +36,7 @@ const RoomHistory = () => {
     data: users,
     error: usersError,
     isLoading: isLoadingUsers,
-  } = useGetAPI<UserAttribute[]>(`${endpoints.users}`);
+  } = useGetAPI<UserAttribute[]>(`${endpoints.users}/${community.communityId}`);
 
   if (isLoadingStayLog || isLoadingUsers) return <Loading message='滞在履歴取得中' />;
   if (stayLogError || usersError) return <Error message='滞在履歴取得失敗' />;


### PR DESCRIPTION
## 概要
ユーザ取得する際のAPIリクエストのパスにコミュニティIDがないせいで取得ミスを起こしていたのを修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ルーム履歴表示がコミュニティ固有のデータのみを取得するよう改善されました。ユーザー情報の表示がより正確になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->